### PR TITLE
chore: modernise to Java 21 and update build toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: coursier/cache-action@v7
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: coursier/cache-action@v8
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
       with:
-        java-version: 1.8
+        distribution: temurin
+        java-version: 21
+    - name: Set up sbt
+      uses: sbt/setup-sbt@v1
     - name: Run tests
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -37,11 +40,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: coursier/cache-action@v7
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: coursier/cache-action@v8
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
         with:
-          java-version: 1.8
+          distribution: temurin
+          java-version: 21
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
       - name: Publish library
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ import sbt.Keys.scalaVersion
 ThisBuild / organization     := "com.intenthq"
 ThisBuild / organizationName := "Intent HQ"
 
-lazy val scala212 = "2.12.12"
-lazy val scala213 = "2.13.3"
+lazy val scala212 = "2.12.20"
+lazy val scala213 = "2.13.15"
 lazy val supportedScalaVersions = List(scala213, scala212)
 
 lazy val root = (project in file("."))
@@ -15,7 +15,7 @@ lazy val root = (project in file("."))
     crossScalaVersions := supportedScalaVersions
   )
 
-testFrameworks += new TestFramework("weaver.framework.TestFramework")
+testFrameworks += new TestFramework("weaver.framework.CatsEffect")
 
 publishTo := Some("GitHub Package Registry (intenthq/scala-secret)" at "https://maven.pkg.github.com/intenthq/scala-secret")
 credentials ++= scala.util.Properties

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,5 @@
 import sbt._
 
 object Dependencies {
-  lazy val weaver = "com.disneystreaming" %% "weaver-framework" % "0.5.1" % "test"
+  lazy val weaver = "com.disneystreaming" %% "weaver-cats" % "0.8.4" % "test"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.10.5


### PR DESCRIPTION
INFRA-868

Closes #19
Closes #22

## Summary

Full modernisation of the build toolchain to Java 21 LTS, superseding the individual Dependabot PRs:

| Component | Before | After |
|---|---|---|
| Java | 1.8 | 21 (LTS) |
| `actions/setup-java` | v1 | v5 (+ `distribution: temurin`) |
| `coursier/cache-action` | v7 | v8 |
| sbt | 1.4.9 | 1.10.5 |
| Scala 2.12 | 2.12.12 | 2.12.20 |
| Scala 2.13 | 2.13.3 | 2.13.15 |
| `weaver-framework` | 0.5.1 | `weaver-cats` 0.8.4 |
| sbt install step | missing | `sbt/setup-sbt@v1` added |

The `weaver-framework` artifact was renamed to `weaver-cats` in 0.6.0, and the test framework class changed from `weaver.framework.TestFramework` to `weaver.framework.CatsEffect`. No changes to test source code were required.

## Test plan
- [ ] `build` job passes with Java 21
- [ ] `sbt test` runs successfully with updated Scala and weaver versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)