### PR TITLE
fix: resolve zizmor excessive-permissions + artipacked (INFRA-869)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,18 @@ on:
     branches:
         - main
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - uses: coursier/cache-action@v8
     - name: Set up JDK 21
       uses: actions/setup-java@v5
@@ -37,9 +43,14 @@ jobs:
     needs: build
     timeout-minutes: 10
     if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')}}
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: coursier/cache-action@v8
       - name: Set up JDK 21
         uses: actions/setup-java@v5


### PR DESCRIPTION
## What

Thin mechanical pass for `scala-secret`: top-level permissions: {} with per-job blocks (build: contents: read; publish: contents: read + packages: write for GitHub Packages maven publish via GITHUB_TOKEN); persist-credentials: false on both checkouts.

**Deliberately deferred** (INFRA-869 cross-cutting decision pending): `unpinned-uses` — the bulk of this repo's findings — awaiting the org pin-vs-SHA vs wrap-in-github-actions call.

Verified with org config `zizmor --config zizmor.yml`: 0 findings outside the deferred set.

INFRA-869

🤖 Generated with [Claude Code](https://claude.com/claude-code)